### PR TITLE
Add comprehensive unit tests for exception handling

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,35 @@
+# Contributing to ShadowBox
+
+Thank you for your interest in improving ShadowBox! I have completed my primary work on this project for now. I am shifting my focus to polish other projects in my portfolio, so I welcome any community contributions to help keep the project stable and secure.
+
+## Workflow
+All contributions should be made via a dedicated **`contribution`** branch to keep the main codebase clean.
+1. Create a new branch from `contribution`: `git checkout contribution`
+2. Create your feature branch: `git checkout -b feature/your-feature-name`
+3. Push your changes and open a Pull Request targeting the `contribution` branch.
+
+## Standards & Best Practices
+
+To keep the codebase clean and maintainable, please follow the following standards I have added:
+
+### 1. PEP 8 & Linting
+* Follow [PEP 8](https://peps.python.org/pep-0008/) style guidelines.
+* Use type hints for all function arguments and return types.
+* Keep the code readable and document any complex logic.
+
+### 2. FastAPI & Async Patterns
+* **Always use `async/await`**: ShadowBox is designed as an asynchronous system. Please avoid blocking I/O operations (like standard `time.sleep` or synchronous file operations) within route handlers or services.
+* **Dependency Injection**: Leverage FastAPI’s `Depends` for database sessions and security handlers. Do not instantiate these manually inside your routes.
+* **Service Layer**: Keep your routes "thin." All business logic and database orchestration must reside in the `app/services/` layer.
+
+### 3. Error Handling
+* **Do not use `try/except` in routers**: We use a centralized `ServiceError` hierarchy. 
+* If a service method encounters an error, it should `raise` the appropriate `ServiceError` (defined in `app/exceptions/exceptions.py`). The global exception handler will automatically catch these and return a consistent JSON response.
+
+### 4. Security
+* Never hardcode sensitive information. Always use environment variables.
+* Ensure that any new endpoints requiring identity verification use the `JWTHandler` dependency.
+
+---
+
+I’m excited to see how this project grows with your help! If you have any questions about the current architecture, feel free to open an issue before starting your work.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 **ShadowBox API**
 
-I have completed my work on this project for now. You are more than welcome to contribute and work on any issues as I am shifting my focus to polish other projects in my portfolio. The API is functional, stable, and uses a modular service-oriented architecture with global error handling.
+I have completed my primary work on this project for now. The API is functional, stable, and uses a modular service-oriented architecture with global error handling.
+
+I am shifting my focus to polish other projects in my portfolio, so you are more than welcome to contribute! If you'd like to help, please see the CONTRIBUTING.md file for guidelines on how to submit changes and maintain the project's standards.
 
 ShadowBox provides a hardened API for storing files with AES-256 encryption at rest. Built for security, the system ensures files are encrypted before hitting the disk and only decrypted upon authorized download. Designed as a modular service, it is perfect for deployment on local networks, private servers, or Raspberry Pi environments.
 

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -21,23 +21,47 @@ def build_test_app() -> FastAPI:
     test_app.add_exception_handler(Exception, unhandled_exception_handler)
 
     @test_app.get("/raise-service-error")
+    def raise_service_error():
+        raise ServiceError()
 
     @test_app.get("/raise-user-exists")
+    def raise_user_exists():
+        raise UserAlreadyExistsError()
 
     @test_app.get("/raise-auth-error")
+    def raise_auth_error():
+        raise AuthenticationError()
 
     @test_app.get("/raise-incorrect-password")
+    def raise_incorrect_password():
+        raise IncorrectPasswordError()
 
     @test_app.get("/raise-file-error")
+    def raise_file_error():
+        raise FileError()
 
     @test_app.get("/raise-encryption-error")
+    def raise_encryption_error():
+        raise EncryptionServiceError()
 
     @test_app.get("/raise-database-error")
+    def raise_database_error():
+        raise DatabaseError()
 
     @test_app.get("/raise-dashboard-error")
+    def raise_dashboard_error():
+        raise DashboardError()
 
     @test_app.get("/raise-unhandled")
+    def raise_unhandled():
+        raise RuntimeError("Something unexpected happened")
 
     @test_app.get("/raise-custom-detail")
+    def raise_custom_detail():
+        raise ServiceError(detail="Custom error message", status_code=422)
 
     return test_app
+
+@pytest.fixture
+def client():
+    return TestClient(build_test_app(), raise_server_exceptions=False)

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -92,15 +92,32 @@ class TestServiceError:
 
 class TestSubclassStatusCodes:
     def test_user_already_exists_error_returns_409(self, client):
+        response = client.get("/raise-user-exists")
+        assert response.status_code == 409
 
     def test_authentication_error_returns_401(self, client):
+        response = client.get("/raise-auth-error")
+        assert response.status_code == 401
 
     def test_incorrect_password_error_returns_401(self, client):
+        response = client.get("/raise-incorrect-password")
+        assert response.status_code == 401
 
     def test_file_error_returns_400(self, client):
+        response = client.get("/raise-file-error")
+        assert response.status_code == 400
 
     def test_encryption_error_returns_500(self, client):
+        response = client.get("/raise-encryption-error")
+        assert response.status_code == 500
 
     def test_database_error_returns_500(self, client):
+        response = client.get("/raise-database-error")
+        assert response.status_code == 500
 
     def test_dashboard_error_returns_500(self, client):
+        response = client.get("/raise-dashboard-error")
+        assert response.status_code == 500
+
+
+# Subclass default detail messages

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -65,3 +65,14 @@ def build_test_app() -> FastAPI:
 @pytest.fixture
 def client():
     return TestClient(build_test_app(), raise_server_exceptions=False)
+
+# ServiceError base class
+
+class TestServiceError:
+    def test_returns_500_status_code(self, client):
+
+    def test_rturns_json_detail_key(self, client):
+
+    def test_returns_default_detail_message(self, client):
+
+    def test_custom_detail_and_status_code(self, client):

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -70,9 +70,18 @@ def client():
 
 class TestServiceError:
     def test_returns_500_status_code(self, client):
+        response = client.get("/raise-service-error")
+        assert response.status_code == 500
 
-    def test_rturns_json_detail_key(self, client):
+    def test_returns_json_detail_key(self, client):
+        response = client.get("/raise-service-error")
+        assert "detail" in response.json()
 
     def test_returns_default_detail_message(self, client):
+        response = client.get("/raise-service-error")
+        assert response.json()["detail"] == "An unexpected error occurred."
 
     def test_custom_detail_and_status_code(self, client):
+        response = client.get("/raise-custom-detail")
+        assert response.json()["detail"] == "Custom error message"
+        assert response.status_code == 422

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -121,3 +121,18 @@ class TestSubclassStatusCodes:
 
 
 # Subclass default detail messages
+
+class TestSubclassDefaultMessages:
+    def test_user_already_exists_message(self, client):
+
+    def test_authentication_error_message(self, client):
+
+    def test_incorrect_password_message(self, client):
+
+    def test_file_error_message(self, client):
+
+    def test_encryption_error_message(self, client):
+
+    def test_database_error_message(self, client):
+
+    def test_dashboard_error_message(self, client):

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -1,0 +1,14 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from app.exceptions.exceptions import (
+    ServiceError,
+    UserAlreadyExistsError,
+    AuthenticationError,
+    IncorrectPasswordError,
+    FileError,
+    EncryptionServiceError,
+    DatabaseError,
+    DashboardError,
+)
+from app.core.exception_handlers import service_exception_handler, unhandled_exception_handler

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -124,15 +124,29 @@ class TestSubclassStatusCodes:
 
 class TestSubclassDefaultMessages:
     def test_user_already_exists_message(self, client):
+        response = client.get("/raise-user-exists")
+        assert response.json()["detail"] == "User already exists."
 
     def test_authentication_error_message(self, client):
+        response = client.get("/raise-auth-error")
+        assert response.json()["detail"] == "Authentication failed."
 
     def test_incorrect_password_message(self, client):
+        response = client.get("/raise-incorrect-password")
+        assert response.json()["detail"] == "Incorrect password."
 
     def test_file_error_message(self, client):
+        response = client.get("/raise-file-error")
+        assert response.json()["detail"] == "File operation failed."
 
     def test_encryption_error_message(self, client):
+        response = client.get("/raise-encryption-error")
+        assert response.json()["detail"] == "Encryption failed."
 
     def test_database_error_message(self, client):
+        response = client.get("/raise-database-error")
+        assert response.json()["detail"] == "Database error."
 
     def test_dashboard_error_message(self, client):
+        response = client.get("/raise-dashboard-error")
+        assert response.json()["detail"] == "Dashboard error."

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -141,7 +141,7 @@ class TestSubclassDefaultMessages:
 
     def test_encryption_error_message(self, client):
         response = client.get("/raise-encryption-error")
-        assert response.json()["detail"] == "Encryption failed."
+        assert response.json()["detail"] == "Encryption error."
 
     def test_database_error_message(self, client):
         response = client.get("/raise-database-error")
@@ -157,7 +157,7 @@ class TestSubclassDefaultMessages:
 class TestResponseStructure:
     def test_response_is_json(self, client):
         response = client.get("/raise-service-error")
-        assert response.headers["content-Type"] == "application/json"
+        assert response.headers["content-type"] == "application/json"
 
     def test_response_has_only_detail_key(self, client):
         response = client.get("/raise-service-error")

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -162,3 +162,11 @@ class TestResponseStructure:
     def test_response_has_only_detail_key(self, client):
         response = client.get("/raise-service-error")
         assert list(response.json().keys()) == ["detail"]
+
+
+# Unhandled exception fallback
+
+class TestUnhandledExceptionHandler:
+    def test_unhandled_exception_returns_500(self, client):
+
+    def test_unhandled_exception_returns_json(self, client):

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -66,6 +66,7 @@ def build_test_app() -> FastAPI:
 def client():
     return TestClient(build_test_app(), raise_server_exceptions=False)
 
+
 # ServiceError base class
 
 class TestServiceError:
@@ -85,3 +86,21 @@ class TestServiceError:
         response = client.get("/raise-custom-detail")
         assert response.json()["detail"] == "Custom error message"
         assert response.status_code == 422
+
+
+# subclass status codes
+
+class TestSubclassStatusCodes:
+    def test_user_already_exists_error_returns_409(self, client):
+
+    def test_authentication_error_returns_401(self, client):
+
+    def test_incorrect_password_error_returns_401(self, client):
+
+    def test_file_error_returns_400(self, client):
+
+    def test_encryption_error_returns_500(self, client):
+
+    def test_database_error_returns_500(self, client):
+
+    def test_dashboard_error_returns_500(self, client):

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -156,5 +156,9 @@ class TestSubclassDefaultMessages:
 
 class TestResponseStructure:
     def test_response_is_json(self, client):
+        response = client.get("/raise-service-error")
+        assert response.headers["content-Type"] == "application/json"
 
     def test_response_has_only_detail_key(self, client):
+        response = client.get("/raise-service-error")
+        assert list(response.json().keys()) == ["detail"]

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -150,3 +150,11 @@ class TestSubclassDefaultMessages:
     def test_dashboard_error_message(self, client):
         response = client.get("/raise-dashboard-error")
         assert response.json()["detail"] == "Dashboard error."
+
+
+# Response structure
+
+class TestResponseStructure:
+    def test_response_is_json(self, client):
+
+    def test_response_has_only_detail_key(self, client):

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -12,3 +12,32 @@ from app.exceptions.exceptions import (
     DashboardError,
 )
 from app.core.exception_handlers import service_exception_handler, unhandled_exception_handler
+
+# Build a minimal test app that mirrors main.py's excpetion handler setup
+# This avoids needing a database or any other infrastructure
+def build_test_app() -> FastAPI:
+    test_app = FastAPI()
+    test_app.add_exception_handler(ServiceError, service_exception_handler)
+    test_app.add_exception_handler(Exception, unhandled_exception_handler)
+
+    @test_app.get("/raise-service-error")
+
+    @test_app.get("/raise-user-exists")
+
+    @test_app.get("/raise-auth-error")
+
+    @test_app.get("/raise-incorrect-password")
+
+    @test_app.get("/raise-file-error")
+
+    @test_app.get("/raise-encryption-error")
+
+    @test_app.get("/raise-database-error")
+
+    @test_app.get("/raise-dashboard-error")
+
+    @test_app.get("/raise-unhandled")
+
+    @test_app.get("/raise-custom-detail")
+
+    return test_app

--- a/app/tests/test_exception_handlers.py
+++ b/app/tests/test_exception_handlers.py
@@ -168,5 +168,9 @@ class TestResponseStructure:
 
 class TestUnhandledExceptionHandler:
     def test_unhandled_exception_returns_500(self, client):
+        response = client.get("/raise-unhandled")
+        assert response.status_code == 500
 
     def test_unhandled_exception_returns_json(self, client):
+        response = client.get("/raise-unhandled")
+        assert "detail" in response.json()


### PR DESCRIPTION
Closes #6

Adds 22 unit tests covering the ServiceError exception hierarchy and both exception handlers registered in main.py.

Test coverage:
-ServiceError base class — default status code, default message, custom detail and status code
-All 7 subclasses — correct HTTP status codes and default detail messages
-Response structure — JSON content type and {"detail": "..."} shape
-Unhandled exception fallback — 500 status and JSON response

Tests use a minimal in-process FastAPI app with TestClient — no database or external infrastructure required. All 22 tests pass.